### PR TITLE
change: set PWR_PIN default state to HIGH for default-on power behaviour

### DIFF
--- a/jetkvm-dc.c
+++ b/jetkvm-dc.c
@@ -294,7 +294,7 @@ int main()
 
     gpio_init(PWR_PIN);
     gpio_set_dir(PWR_PIN, GPIO_OUT);
-    gpio_put(PWR_PIN, 0);
+    gpio_put(PWR_PIN, 1);
     
     power_init();
 


### PR DESCRIPTION
This PR updates the system initialisation to set PWR_PIN to HIGH using gpio_put(PWR_PIN, 1);.

Previously, the pin was set to LOW, so devices remained unpowered after a reboot or power cut until manually turned on via UART. With this change, the system will automatically power on connected devices after boot, enabling unattended recovery following a power interruption.

Changes:
- gpio_put(PWR_PIN, 0); → gpio_put(PWR_PIN, 1); in main()

Impact:
Devices connected to PWR_PIN will now be powered immediately on boot.
This enables automatic recovery after power loss, but systems expecting manual activation may require adjustments.