### PR TITLE
Storing power state and power restore behave after a complete power loss.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ pico_sdk_init()
 
 # Add executable. Default name is the project name, version 0.1
 
-add_executable(jetkvm-dc jetkvm-dc.c driver_ina219.c)
+add_executable(jetkvm-dc jetkvm-dc.c driver_ina219.c flash_store.c)
 
 pico_set_program_name(jetkvm-dc "jetkvm-dc")
 pico_set_program_version(jetkvm-dc "0.1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,12 @@ project(jetkvm-dc C CXX ASM)
 # Initialise the Raspberry Pi Pico SDK
 pico_sdk_init()
 
-# Add executable. Default name is the project name, version 0.1
+# Add executable. Default name is the project name.
 
 add_executable(jetkvm-dc jetkvm-dc.c driver_ina219.c flash_store.c)
 
 pico_set_program_name(jetkvm-dc "jetkvm-dc")
-pico_set_program_version(jetkvm-dc "0.1")
+pico_set_program_version(jetkvm-dc "0.2")
 
 # Modify the below lines to enable/disable output over UART/USB
 pico_enable_stdio_uart(jetkvm-dc 0)

--- a/flash_store.c
+++ b/flash_store.c
@@ -1,0 +1,100 @@
+#include "flash_store.h"
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include <string.h>
+
+#define FLASH_TARGET_OFFSET     (512 * 1024)           // Offset where entries are stored
+#define ENTRY_SIZE              2                      // 1 byte for each value
+#define ENTRIES_PER_SECTOR      (FLASH_SECTOR_SIZE / FLASH_PAGE_SIZE)  // 16 entries
+#define INVALID_BYTE            0xFF
+
+typedef struct {
+    uint8_t gpio_state;
+    uint8_t mode_value;
+} FlashEntry;
+
+static FlashEntry current_entry;
+
+// Search the last valid entry in the flash sector
+static FlashEntry flash_read_last_entry(void) {
+    const uint8_t *flash = (const uint8_t *)(XIP_BASE + FLASH_TARGET_OFFSET);
+    FlashEntry entry;
+
+    // Scan backwards to find the last valid entry
+    for (int i = ENTRIES_PER_SECTOR - 1; i >= 0; i--) {
+        const uint8_t *entry_ptr = flash + i * FLASH_PAGE_SIZE;
+
+        // Check if the first byte is valid (not 0xFF)
+        if (entry_ptr[0] != INVALID_BYTE) {
+            memcpy(&entry, entry_ptr, ENTRY_SIZE);
+
+            // Sanity check
+            if (entry.gpio_state <= POWER_ON && entry.mode_value <= RESTORE_MODE_LAST_STATE) {
+                return entry;
+            }
+        }
+    }
+
+    // No valid entry found – return default
+    FlashEntry default_entry = { POWER_OFF, RESTORE_MODE_OFF };
+    return default_entry;
+}
+
+static void flash_write_entry(uint8_t gpio_state, uint8_t mode_value) {
+    const uint8_t *flash = (const uint8_t *)(XIP_BASE + FLASH_TARGET_OFFSET);
+
+    // Find the next free slot
+    int entry_index = 0;
+    for (; entry_index < ENTRIES_PER_SECTOR; entry_index++) {
+        if (flash[entry_index * FLASH_PAGE_SIZE] == INVALID_BYTE) {
+            break;
+        }
+    }
+
+    // Sector full – erase and reset
+    if (entry_index >= ENTRIES_PER_SECTOR) {
+        uint32_t ints = save_and_disable_interrupts();
+        flash_range_erase(FLASH_TARGET_OFFSET, FLASH_SECTOR_SIZE);
+        restore_interrupts(ints);
+        entry_index = 0;
+    }
+
+    FlashEntry entry = { gpio_state, mode_value };
+
+    uint8_t buffer[FLASH_PAGE_SIZE];
+    memset(buffer, 0xFF, FLASH_PAGE_SIZE);
+    memcpy(buffer, &entry, ENTRY_SIZE);
+
+    uint32_t ints = save_and_disable_interrupts();
+    flash_range_program(FLASH_TARGET_OFFSET + entry_index * FLASH_PAGE_SIZE, buffer, FLASH_PAGE_SIZE);
+    restore_interrupts(ints);
+}
+
+// Initializes the RAM copy from flash
+void flash_store_init(void) {
+    current_entry = flash_read_last_entry();
+}
+
+// Public API
+
+void set_power_state(uint8_t state) {
+    if (state != current_entry.gpio_state) {
+        current_entry.gpio_state = state;
+        flash_write_entry(current_entry.gpio_state, current_entry.mode_value);
+    }
+}
+
+uint8_t get_power_state(void) {
+    return current_entry.gpio_state;
+}
+
+void set_restore_mode(uint8_t mode) {
+    if (mode != current_entry.mode_value) {
+        current_entry.mode_value = mode;
+        flash_write_entry(current_entry.gpio_state, current_entry.mode_value);
+    }
+}
+
+uint8_t get_restore_mode(void) {
+    return current_entry.mode_value;
+}

--- a/flash_store.h
+++ b/flash_store.h
@@ -1,0 +1,24 @@
+#ifndef FLASH_STORE_H
+#define FLASH_STORE_H
+
+#include <stdint.h>
+
+// GPIO state values
+#define POWER_OFF   0
+#define POWER_ON    1
+
+// Mode values
+#define RESTORE_MODE_OFF            0
+#define RESTORE_MODE_ON             1
+#define RESTORE_MODE_LAST_STATE     2
+
+// Public API
+void flash_store_init(void);
+
+void set_power_state(uint8_t state);
+uint8_t get_power_state(void);
+
+void set_restore_mode(uint8_t mode);
+uint8_t get_restore_mode(void);
+
+#endif // FLASH_STORE_H


### PR DESCRIPTION
This pull request adds a robust flash storage mechanism to persist the device’s power state (POWER_ON / POWER_OFF) and restore mode (OFF, ON, LAST_STATE)  after a power loss. 

The implementation is optimized for flash longevity by incorporating wear-leveling using entry rotation across a flash sector.

**🔧 What’s included**
- New flash_store.c and flash_store.h modules for abstracted state persistence
- Each flash entry (2 bytes) is stored in a dedicated 256-byte page (required by RP2040 hardware)
- A 4KB flash sector is used as a ring buffer for up to 16 entries
- Flash writes are 256-byte aligned and only occur on actual state changes
- Old entries are preserved until the sector is full, then erased and reused from the beginning
- Automatic validation and fallback to default values on cold boot

**✅ Benefits**
- State survives power loss or resets
- Wear-leveling ensures long-term reliability (~1.6 million safe writes per 4KB sector)
- Clean and extensible design (e.g., additional state fields can be added later)
- RAM-cached values for fast get_ access (no repeated flash reads)

**🧪 How it works**
- On startup, the last valid flash entry is scanned and loaded
- Any write operation checks if a change actually occurred before writing to flash
- When all 16 pages are used, the sector is erased and writing restarts from page 0

**📎 Notes**
- Flash write alignment and erase rules strictly follow the RP2040 SDK requirements
- The write frequency should still be kept as low as possible to further increase lifespan

To control this feature an app update for kvm is required. See https://github.com/jetkvm/kvm/pull/672